### PR TITLE
Bugfixes for RMPP large images

### DIFF
--- a/remarkable_update_image/cpio.py
+++ b/remarkable_update_image/cpio.py
@@ -280,7 +280,7 @@ class Entry:
         return False
 
     def seekable(self):
-        return False
+        return True
 
     def readable(self):
         return True

--- a/remarkable_update_image/image.py
+++ b/remarkable_update_image/image.py
@@ -375,7 +375,13 @@ class CPIOUpdateImage(io.RawIOBase):
         if key in self._cache:
             return self._cache[key]
 
-        self._cache[key] = data = self._image.read(size)
+        data = self._image.read(size)
+        try:
+            self._cache[key] = data
+        except ValueError as err:
+            if str(err) != "value too large":
+                raise err
+
         return data
 
     def peek(self, size=0):
@@ -383,7 +389,13 @@ class CPIOUpdateImage(io.RawIOBase):
         if key in self._cache:
             return self._cache[key]
 
-        self._cache[key] = data = self._image.peek(size)
+        data = self._image.peek(size)
+        try:
+            self._cache[key] = data
+        except ValueError as err:
+            if str(err) != "value too large":
+                raise err
+
         return data
 
 


### PR DESCRIPTION
Fixes two problems I had:
1. With large image files like 3.20.0.92 for RMPP (~600MB when extracted) `read` and `peek` calls exceed the fixed cache size of 500MB. Added simple try-except blocks to guard the cache insertion and fail gracefully. 
2. Made `Entry` seekable in `cpio.py` to allow IndexedGzipFile to work correctly with CPIO entries

For context I am using MacOS 15.6.1 (ARM), but tested on my windows and linux (x86) machines which gave the same error messages.

Traces for related errors:

1. `ValueError: value too large`
```
Traceback (most recent call last):
  File "/Users/jswent/tmp/remarkable/.venv/lib/python3.12/site-packages/codexctl/__init__.py", line 102, in call_func
    f.write(image.read())
            ^^^^^^^^^^^^
  File "/Users/jswent/tmp/remarkable/.venv/lib/python3.12/site-packages/remarkable_update_image/image.py", line 378, in read
  File "/Users/jswent/tmp/remarkable/.venv/lib/python3.12/site-packages/cachetools/__init__.py", line 423, in __setitem__
    cache_setitem(self, key, value)
  File "/Users/jswent/tmp/remarkable/.venv/lib/python3.12/site-packages/cachetools/__init__.py", line 76, in __setitem__
    raise ValueError("value too large")
ValueError: value too large
```

2. `ZRAN_READ_FAIL` from IndexedGzipFile
```
Traceback (most recent call last):
  File "/Users/jswent/tmp/remarkable/out/extract.py", line 7, in <module>
    f.write(image.read())
            ^^^^^^^^^^^^
  File "/Users/jswent/tmp/remarkable/.venv/lib/python3.12/site-packages/remarkable_update_image/image.py", line 378, in read
  File "indexed_gzip/indexed_gzip.pyx", line 708, in indexed_gzip.indexed_gzip._IndexedGzipFile.read
  File "indexed_gzip/indexed_gzip.pyx", line 746, in indexed_gzip.indexed_gzip._IndexedGzipFile.read
indexed_gzip.indexed_gzip.ZranError: zran_read returned error: ZRAN_READ_FAIL (file: b'remarkable-production-image-3.20.0.92-ferrari-public.ext4.verity.gz')
```