### PR TITLE
Fix trying to read larger than the cache size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          cache: 'pip'
+          python-version: "3.11"
+          cache: "pip"
       - name: Lint code
         run: make ${{ env.FLAGS }} lint format
   test:
@@ -36,8 +36,8 @@ jobs:
           - macos
           - windows
         python:
-          - '3.11'
-          - '3.12'
+          - "3.11"
+          - "3.12"
     steps:
       - name: Debug flags
         shell: bash
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install wheel
         run: pip install wheel
       - name: Cache test files
@@ -60,6 +60,7 @@ jobs:
           path: |
             .venv/bin/codexctl.*
             .venv/*_reMarkable2-*.signed
+            .venv/remarkable-production-memfault-image-*-public
           key: test-files-${{ hashFiles('Makefile') }}
       - name: Run tests
         shell: bash
@@ -75,8 +76,8 @@ jobs:
           - macos
           - windows
         python:
-          - '3.11'
-          - '3.12'
+          - "3.11"
+          - "3.12"
     steps:
       - name: Debug flags
         shell: bash
@@ -89,7 +90,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install wheel
         if: matrix.os != 'ubuntu'
         run: pip install wheel
@@ -142,8 +143,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          cache: 'pip'
+          python-version: "3.11"
+          cache: "pip"
       - name: Install wheel
         run: pip install wheel
       - name: Building package
@@ -162,13 +163,13 @@ jobs:
     strategy:
       matrix:
         artifact:
-          - 'pip-sdist'
-          - 'pip-wheel-ubuntu-3.11'
-          - 'pip-wheel-ubuntu-3.12'
-          - 'pip-wheel-macos-3.11'
-          - 'pip-wheel-macos-3.12'
-          - 'pip-wheel-windows-3.11'
-          - 'pip-wheel-windows-3.12'
+          - "pip-sdist"
+          - "pip-wheel-ubuntu-3.11"
+          - "pip-wheel-ubuntu-3.12"
+          - "pip-wheel-macos-3.11"
+          - "pip-wheel-macos-3.12"
+          - "pip-wheel-windows-3.11"
+          - "pip-wheel-windows-3.12"
     permissions:
       id-token: write
       contents: write
@@ -195,13 +196,13 @@ jobs:
       fail-fast: false
       matrix:
         artifact:
-          - 'pip-sdist'
-          - 'pip-wheel-ubuntu-3.11'
-          - 'pip-wheel-ubuntu-3.12'
-          - 'pip-wheel-macos-3.11'
-          - 'pip-wheel-macos-3.12'
-          - 'pip-wheel-windows-3.11'
-          - 'pip-wheel-windows-3.12'
+          - "pip-sdist"
+          - "pip-wheel-ubuntu-3.11"
+          - "pip-wheel-ubuntu-3.12"
+          - "pip-wheel-macos-3.11"
+          - "pip-wheel-macos-3.12"
+          - "pip-wheel-windows-3.11"
+          - "pip-wheel-windows-3.12"
     permissions:
       contents: write
     steps:
@@ -214,8 +215,7 @@ jobs:
           name: ${{ matrix.artifact }}
           path: dist
       - name: Upload to release
-        run:
-          find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
+        run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .DEFAULT_GOAL := all
 VERSION := $(shell grep -m 1 version pyproject.toml | tr -s ' ' | tr -d "'\":" | cut -d' ' -f3)
 PACKAGE := $(shell grep -m 1 name pyproject.toml | tr -s ' ' | tr -d "'\":" | cut -d' ' -f3)
-FW_VERSION := 2.15.1.1189
-FW_DATA := wVbHkgKisg-
-NEW_FW_VERSION=3.11.3.3
+RM2_FW_VERSION := 2.15.1.1189
+RM2_FW_DATA := wVbHkgKisg-
+RM1_FW_VERSION=3.11.3.3
+RMPP_FW_VERSION=3.20.0.92
 
 SHELL := /bin/bash
 ifeq ($(OS),Windows_NT)
@@ -109,12 +110,17 @@ ${VENV_BIN_ACTIVATE}: requirements.txt
 	unzip -n .venv/codexctl.zip -d .venv/bin
 	chmod +x .venv/bin/${CODEXCTL_BIN}
 
-.venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed: .venv/bin/${CODEXCTL_BIN}
-	.venv/bin/${CODEXCTL_BIN} download --hardware remarkable2 --out .venv ${FW_VERSION}
+IMAGES := .venv/${RM2_FW_VERSION}_reMarkable2-${RM2_FW_DATA}.signed
+.venv/${RM2_FW_VERSION}_reMarkable2-${RM2_FW_DATA}.signed: .venv/bin/${CODEXCTL_BIN}
+	.venv/bin/${CODEXCTL_BIN} download --hardware remarkable2 --out .venv ${RM2_FW_VERSION}
 
-.venv/remarkable-production-memfault-image-${NEW_FW_VERSION}-remarkable1-public: .venv/bin/${CODEXCTL_BIN}
-	.venv/bin/${CODEXCTL_BIN} download --hardware remarkable1 --out .venv ${NEW_FW_VERSION}
+IMAGES += .venv/remarkable-production-memfault-image-${RM1_FW_VERSION}-remarkable1-public
+.venv/remarkable-production-memfault-image-${RM1_FW_VERSION}-remarkable1-public: .venv/bin/${CODEXCTL_BIN}
+	.venv/bin/${CODEXCTL_BIN} download --hardware rmpp --out .venv ${RM1_FW_VERSION}
 
+IMAGES += .venv/remarkable-production-memfault-image-${RMPP_FW_VERSION}-rmpp-public
+.venv/remarkable-production-memfault-image-${RMPP_FW_VERSION}-rmpp-public: .venv/bin/${CODEXCTL_BIN}
+	.venv/bin/${CODEXCTL_BIN} download --hardware rmpp --out .venv ${RMPP_FW_VERSION}
 
 $(PROTO_OBJ): $(PROTO_SOURCE) ${VENV_BIN_ACTIVATE}
 	. ${VENV_BIN_ACTIVATE}; \
@@ -123,7 +129,7 @@ $(PROTO_OBJ): $(PROTO_SOURCE) ${VENV_BIN_ACTIVATE}
 	    --proto_path=protobuf \
 	    $(PROTO_SOURCE)
 
-test: ${VENV_BIN_ACTIVATE} .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed .venv/remarkable-production-memfault-image-${NEW_FW_VERSION}-remarkable1-public $(OBJ)
+test: ${VENV_BIN_ACTIVATE} $(IMAGES) $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u test.py
 

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ IMAGES := .venv/${RM2_FW_VERSION}_reMarkable2-${RM2_FW_DATA}.signed
 
 IMAGES += .venv/remarkable-production-memfault-image-${RM1_FW_VERSION}-remarkable1-public
 .venv/remarkable-production-memfault-image-${RM1_FW_VERSION}-remarkable1-public: .venv/bin/${CODEXCTL_BIN}
-	.venv/bin/${CODEXCTL_BIN} download --hardware rmpp --out .venv ${RM1_FW_VERSION}
+	.venv/bin/${CODEXCTL_BIN} download --hardware remarkable1 --out .venv ${RM1_FW_VERSION}
 
 IMAGES += .venv/remarkable-production-memfault-image-${RMPP_FW_VERSION}-rmpp-public
 .venv/remarkable-production-memfault-image-${RMPP_FW_VERSION}-rmpp-public: .venv/bin/${CODEXCTL_BIN}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION := $(shell grep -m 1 version pyproject.toml | tr -s ' ' | tr -d "'\":" |
 PACKAGE := $(shell grep -m 1 name pyproject.toml | tr -s ' ' | tr -d "'\":" | cut -d' ' -f3)
 FW_VERSION := 2.15.1.1189
 FW_DATA := wVbHkgKisg-
+NEW_FW_VERSION=3.11.3.3
 
 SHELL := /bin/bash
 ifeq ($(OS),Windows_NT)
@@ -10,8 +11,8 @@ ifeq ($(OS),Windows_NT)
 	ifeq ($(VENV_BIN_ACTIVATE),)
 		VENV_BIN_ACTIVATE := .venv/Scripts/activate
 	endif
-	CODEXCTL := https://github.com/Jayy001/codexctl/releases/download/1719419372/windows-latest.zip
-	CODEXCTL_HASH := 9d1467170be4afcab446c509f24f7422cec76b525c9067380f8b9ac43d81f61f
+	CODEXCTL := https://github.com/Jayy001/codexctl/releases/download/1752948641/windows-latest.zip
+	CODEXCTL_HASH := a3c2164e8ec4f04bf059dfcd1cc216e5911f24e37ce236c25a8b420421d3266a
 	CODEXCTL_BIN := codexctl.exe
 else
 	ifeq ($(VENV_BIN_ACTIVATE),)
@@ -19,13 +20,13 @@ else
 	endif
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
-		CODEXCTL := https://github.com/Jayy001/codexctl/releases/download/1719419372/macos-latest.zip
-		CODEXCTL_HASH := 5056e489c8ca346352bfe441229e5c5efb1d9784f806200aa492a512ba636c38
+		CODEXCTL := https://github.com/Jayy001/codexctl/releases/download/1752948641/macos-latest.zip
+		CODEXCTL_HASH := 34da200b09bba09c92a7b0c39ec5dfc6b0fa5d303a750da5a1c60d715d5016e4
 	else
-		CODEXCTL := https://github.com/Jayy001/codexctl/releases/download/1719419372/ubuntu-latest.zip
-		CODEXCTL_HASH := 210f68f8a2136120b706c29852f9b7ce306d6e30d2f6124eb23eb25e858685e5
+		CODEXCTL := https://github.com/Jayy001/codexctl/releases/download/1752948641/ubuntu-latest.zip
+		CODEXCTL_HASH := 209d192788576eb9d631cff8d69702ccf67bc3be07573b0adfe0ea3dc32d0227
 	endif
-	CODEXCTL_BIN := codexctl.bin
+	CODEXCTL_BIN := codexctl
 endif
 
 PROTO_SOURCE := $(wildcard protobuf/*.proto)
@@ -109,7 +110,10 @@ ${VENV_BIN_ACTIVATE}: requirements.txt
 	chmod +x .venv/bin/${CODEXCTL_BIN}
 
 .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed: .venv/bin/${CODEXCTL_BIN}
-	.venv/bin/${CODEXCTL_BIN} download --out .venv ${FW_VERSION}
+	.venv/bin/${CODEXCTL_BIN} download --hardware remarkable2 --out .venv ${FW_VERSION}
+
+.venv/remarkable-production-memfault-image-${NEW_FW_VERSION}-remarkable1-public: .venv/bin/${CODEXCTL_BIN}
+	.venv/bin/${CODEXCTL_BIN} download --hardware remarkable1 --out .venv ${NEW_FW_VERSION}
 
 
 $(PROTO_OBJ): $(PROTO_SOURCE) ${VENV_BIN_ACTIVATE}
@@ -119,7 +123,7 @@ $(PROTO_OBJ): $(PROTO_SOURCE) ${VENV_BIN_ACTIVATE}
 	    --proto_path=protobuf \
 	    $(PROTO_SOURCE)
 
-test: ${VENV_BIN_ACTIVATE} .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed $(OBJ)
+test: ${VENV_BIN_ACTIVATE} .venv/${FW_VERSION}_reMarkable2-${FW_DATA}.signed .venv/remarkable-production-memfault-image-${NEW_FW_VERSION}-remarkable1-public $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u test.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remarkable_update_image"
-version = "1.1.6"
+version = "1.1.7"
 authors = [
   { name="Eeems", email="eeems@eeems.email" },
 ]

--- a/remarkable_update_image/cpio.py
+++ b/remarkable_update_image/cpio.py
@@ -280,7 +280,7 @@ class Entry:
         return False
 
     def seekable(self):
-        return False
+        return True
 
     def readable(self):
         return True

--- a/remarkable_update_image/image.py
+++ b/remarkable_update_image/image.py
@@ -193,7 +193,7 @@ class ProtobufUpdateImage(io.RawIOBase):
         return False
 
     def seekable(self):
-        return False
+        return True
 
     def readable(self):
         return True
@@ -366,7 +366,7 @@ class CPIOUpdateImage(io.RawIOBase):
         return False
 
     def seekable(self):
-        return False
+        return True
 
     def readable(self):
         return True

--- a/remarkable_update_image/image.py
+++ b/remarkable_update_image/image.py
@@ -59,7 +59,7 @@ class UpdateImageException(Exception):
 
 class UpdateImageSignatureException(UpdateImageException):
     def __init__(self, message, signed_hash, actual_hash):
-        super().__init__(self, message)
+        super().__init__(message)
         self.signed_hash = signed_hash
         self.actual_hash = actual_hash
 
@@ -354,6 +354,13 @@ class CPIOUpdateImage(io.RawIOBase):
 
     def expire(self):
         self._cache.expire()
+
+    def close(self):
+        try:
+            self._archive.close()
+
+        finally:
+            return super().close()
 
     def writable(self):
         return False

--- a/remarkable_update_image/image.py
+++ b/remarkable_update_image/image.py
@@ -211,7 +211,7 @@ class ProtobufUpdateImage(io.RawIOBase):
         elif whence == os.SEEK_CUR:
             self._pos = min(max(self._pos + offset, 0), self._size)
         elif whence == os.SEEK_END:
-            self._pos = min(max(self._pos + offset + self._size, 0), self._size)
+            self._pos = min(max(self._size + offset, 0), self._size)
         return self._pos
 
     def tell(self):
@@ -360,7 +360,7 @@ class CPIOUpdateImage(io.RawIOBase):
             self._archive.close()
 
         finally:
-            return super().close()
+            super().close()
 
     def writable(self):
         return False

--- a/test.py
+++ b/test.py
@@ -125,133 +125,132 @@ def assert_ls(path, expected):
 
 
 path = ".venv/remarkable-production-memfault-image-3.11.3.3-remarkable1-public"
-if os.path.exists(path):
-    image = UpdateImage(path)
-    volume = ext4.Volume(image)
-    assert_ls(
-        "/",
-        [
-            ".",
-            "..",
-            "lost+found",
-            "bin",
-            "boot",
-            "dev",
-            "etc",
-            "home",
-            "lib",
-            "media",
-            "mnt",
-            "postinst",
-            "proc",
-            "run",
-            "sbin",
-            "srv",
-            "sys",
-            "tmp",
-            "uboot-version",
-            "usr",
-            "var",
-        ],
-    )
-    assert_ls(
-        "/bin",
-        [
-            ".",
-            "..",
-            "rmdir",
-            "sed",
-            "chgrp",
-            "systemctl",
-            "bash.bash",
-            "mountpoint",
-            "chattr",
-            "stat",
-            "mount",
-            "busybox",
-            "systemd-sysext",
-            "networkctl",
-            "chown",
-            "systemd-tmpfiles",
-            "mktemp",
-            "lsmod",
-            "stty",
-            "kill",
-            "cpio",
-            "true",
-            "gzip",
-            "df",
-            "ps",
-            "systemd-sysusers",
-            "systemd-machine-id-setup",
-            "dnsdomainname",
-            "netstat",
-            "dumpkmap",
-            "su.shadow",
-            "systemd-tty-ask-password-agent",
-            "date",
-            "kmod",
-            "systemd-escape",
-            "ln",
-            "loginctl",
-            "watch",
-            "dmesg",
-            "uname",
-            "dd",
-            "chmod",
-            "busybox.nosuid",
-            "busybox.suid",
-            "usleep",
-            "umount.util-linux",
-            "cp",
-            "more",
-            "login",
-            "journalctl",
-            "ls",
-            "false",
-            "systemd-creds",
-            "ash",
-            "hostname",
-            "touch",
-            "base32",
-            "ping",
-            "sleep",
-            "pidof",
-            "systemd-inhibit",
-            "grep",
-            "tar",
-            "getopt",
-            "zcat",
-            "umount",
-            "egrep",
-            "mknod",
-            "rm",
-            "fgrep",
-            "cat",
-            "sh",
-            "pwd",
-            "vi",
-            "rev",
-            "mkdir",
-            "systemd-hwdb",
-            "gunzip",
-            "sync",
-            "login.shadow",
-            "lsmod.kmod",
-            "systemd-notify",
-            "systemd-ask-password",
-            "su",
-            "systemd-firstboot",
-            "mv",
-            "udevadm",
-            "bash",
-            "echo",
-            "mount.util-linux",
-            "run-parts",
-        ],
-    )
-    assert_symlink_to("/bin/ash", b"/bin/busybox.nosuid")
-    image.close()
+image = UpdateImage(path)
+volume = ext4.Volume(image)
+assert_ls(
+    "/",
+    [
+        ".",
+        "..",
+        "lost+found",
+        "bin",
+        "boot",
+        "dev",
+        "etc",
+        "home",
+        "lib",
+        "media",
+        "mnt",
+        "postinst",
+        "proc",
+        "run",
+        "sbin",
+        "srv",
+        "sys",
+        "tmp",
+        "uboot-version",
+        "usr",
+        "var",
+    ],
+)
+assert_ls(
+    "/bin",
+    [
+        ".",
+        "..",
+        "rmdir",
+        "sed",
+        "chgrp",
+        "systemctl",
+        "bash.bash",
+        "mountpoint",
+        "chattr",
+        "stat",
+        "mount",
+        "busybox",
+        "systemd-sysext",
+        "networkctl",
+        "chown",
+        "systemd-tmpfiles",
+        "mktemp",
+        "lsmod",
+        "stty",
+        "kill",
+        "cpio",
+        "true",
+        "gzip",
+        "df",
+        "ps",
+        "systemd-sysusers",
+        "systemd-machine-id-setup",
+        "dnsdomainname",
+        "netstat",
+        "dumpkmap",
+        "su.shadow",
+        "systemd-tty-ask-password-agent",
+        "date",
+        "kmod",
+        "systemd-escape",
+        "ln",
+        "loginctl",
+        "watch",
+        "dmesg",
+        "uname",
+        "dd",
+        "chmod",
+        "busybox.nosuid",
+        "busybox.suid",
+        "usleep",
+        "umount.util-linux",
+        "cp",
+        "more",
+        "login",
+        "journalctl",
+        "ls",
+        "false",
+        "systemd-creds",
+        "ash",
+        "hostname",
+        "touch",
+        "base32",
+        "ping",
+        "sleep",
+        "pidof",
+        "systemd-inhibit",
+        "grep",
+        "tar",
+        "getopt",
+        "zcat",
+        "umount",
+        "egrep",
+        "mknod",
+        "rm",
+        "fgrep",
+        "cat",
+        "sh",
+        "pwd",
+        "vi",
+        "rev",
+        "mkdir",
+        "systemd-hwdb",
+        "gunzip",
+        "sync",
+        "login.shadow",
+        "lsmod.kmod",
+        "systemd-notify",
+        "systemd-ask-password",
+        "su",
+        "systemd-firstboot",
+        "mv",
+        "udevadm",
+        "bash",
+        "echo",
+        "mount.util-linux",
+        "run-parts",
+    ],
+)
+assert_symlink_to("/bin/ash", b"/bin/busybox.nosuid")
+image.close()
 
 cache_size = 1
 raw_cache_size = cache_size * 1024 * 1024
@@ -402,7 +401,7 @@ except OSError as e:
         print(f"  Unexpected error: {os.strerror(e)}")
 
 
-print("checking writing full image to file: ", end="")
+print("checking writing full protobuf image to file: ", end="")
 try:
     image.seek(0, os.SEEK_SET)
     with TemporaryFile(mode="wb") as f:
@@ -410,7 +409,7 @@ try:
         if "fc7d145e18f14a1a3f435f2fd5ca5924fe8dfe59bf45605dc540deed59551ae4" != digest:
             raise Exception(f"Incorrect digest: {digest}")
 
-        f.write(image.peek())
+        _ = f.write(image.peek())
 
     print("pass")
 
@@ -427,6 +426,28 @@ assert_raw_byte(0x00100002, b"\x00")
 
 image.close()
 
+
+path = ".venv/remarkable-production-memfault-image-3.20.0.92-rmpp-public"
+image = UpdateImage(path)
+print("checking writing full cpio image to file: ", end="")
+try:
+    image.seek(0, os.SEEK_SET)
+    with TemporaryFile(mode="wb") as f:
+        digest = sha256(image.peek()).hexdigest()
+        if "e8eec783c885df92d05dd53ba454949b6f0e5bd793038013df092786b54d6d5d" != digest:
+            raise Exception(f"Incorrect digest: {digest}")
+
+        _ = f.write(image.read())
+
+    print("pass")
+
+except Exception as e:
+    FAILED = True
+    print("fail")
+    print("  ", end="")
+    print(e)
+
+image.close()
 
 if FAILED:
     sys.exit(1)

--- a/test.py
+++ b/test.py
@@ -12,16 +12,9 @@ from hashlib import md5
 from hashlib import sha256
 from remarkable_update_image import UpdateImage
 from remarkable_update_image import UpdateImageSignatureException
+from remarkable_update_image.image import sizeof_fmt
 
 FAILED = False
-
-
-def sizeof_fmt(num, suffix="B"):
-    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
-        if abs(num) < 1024.0:
-            return f"{num:3.1f}{unit}{suffix}"
-        num /= 1024.0
-    return f"{num:.1f}Yi{suffix}"
 
 
 def assert_byte(offset, byte):
@@ -409,7 +402,7 @@ try:
         if "fc7d145e18f14a1a3f435f2fd5ca5924fe8dfe59bf45605dc540deed59551ae4" != digest:
             raise Exception(f"Incorrect digest: {digest}")
 
-        _ = f.write(image.peek())
+        _ = f.write(image.read())
 
     print("pass")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reMarkable 1, reMarkable 2 and RMPP image artifacts and multi-image build/test flow.

* **Improvements**
  * Updated auxiliary tooling downloads, hashes and simplified binary naming/paths across OSes.
  * Improved image handling: seekable reads, selective caching, explicit close/cleanup, and aggregated image targets for testing.

* **Tests**
  * Added cache-size, image integrity, signature verification, directory/symlink checks, and expanded image write tests.

* **Chores**
  * Bumped project version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->