### PR TITLE
Add any wheel, update ext4, only build native wheels on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
         if: runner.debug == '1'
         run: echo 'FLAGS=-d' >> "$GITHUB_ENV"
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -48,8 +48,8 @@ jobs:
         if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'
         run: brew install coreutils
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -66,6 +66,7 @@ jobs:
         run: make ${{ env.FLAGS }} test
   build-wheel:
     name: Build ${{ matrix.os}}-py${{ matrix.python }} wheel
+    if: github.repository == 'Eeems/remarkable-update-image' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
     needs: [lint, test]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -86,10 +87,10 @@ jobs:
         if: runner.debug == '1'
         run: echo 'FLAGS=-d' >> "$GITHUB_ENV"
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
         if: matrix.os != 'ubuntu-latest'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -102,8 +103,8 @@ jobs:
       - name: Building package
         if: matrix.os != 'ubuntu-latest'
         shell: bash
-        run: make ${{ env.FLAGS }} wheel
-      - uses: actions/upload-artifact@v4
+        run: make ${{ env.FLAGS }} native-wheel
+      - uses: actions/upload-artifact@v6
         if: matrix.os != 'ubuntu-latest'
         with:
           name: pip-wheel-${{ matrix.os }}-${{ matrix.python }}
@@ -126,11 +127,32 @@ jobs:
           docker run -v $(pwd):/src \
             quay.io/pypa/manylinux_2_34_x86_64:latest \
             /bin/bash -c "$script"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: matrix.os == 'ubuntu-latest'
         with:
           name: pip-wheel-${{ matrix.os }}-${{ matrix.python }}
           path: wheelhouse/*
+          if-no-files-found: error
+  build-any-wheel:
+    name: Build wheel
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    steps:
+      - name: Checkout the Git repository
+        uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install build tool
+        run: pip install build
+      - name: Building package
+        run: make wheel
+      - uses: actions/upload-artifact@v6
+        with:
+          name: pip-wheel-none-any
+          path: dist/*
           if-no-files-found: error
   build-sdist:
     name: Build sdist
@@ -142,9 +164,9 @@ jobs:
         if: runner.debug == '1'
         run: echo 'FLAGS=-d' >> "$GITHUB_ENV"
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -153,7 +175,7 @@ jobs:
       - name: Building package
         shell: bash
         run: make ${{ env.FLAGS }} sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pip-sdist
           path: dist/*
@@ -161,24 +183,11 @@ jobs:
   publish:
     name: Publish to PyPi
     if: github.repository == 'Eeems/remarkable-update-image' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
-    needs: [build-sdist, build-wheel]
+    needs: &release-needs
+      - build-sdist
+      - build-any-wheel
+      - build-wheel
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        artifact:
-          - "pip-sdist"
-          - "pip-wheel-ubuntu-latest-3.11"
-          - "pip-wheel-ubuntu-latest-3.12"
-          - "pip-wheel-ubuntu-latest-3.13"
-          - "pip-wheel-windows-latest-3.11"
-          - "pip-wheel-windows-latest-3.12"
-          - "pip-wheel-windows-latest-3.13"
-          - "pip-wheel-macos-latest-3.11"
-          - "pip-wheel-macos-latest-3.12"
-          - "pip-wheel-macos-latest-3.13"
-          - "pip-wheel-macos-15-intel-3.11"
-          - "pip-wheel-macos-15-intel-3.12"
-          - "pip-wheel-macos-15-intel-3.13"
     permissions:
       id-token: write
       contents: write
@@ -186,11 +195,12 @@ jobs:
       name: pypi
       url: https://pypi.org/p/remarkable_update_image
     steps:
-      - name: Download artifact
+      - name: Download pip packages
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.artifact }}
+          pattern: pip-*
+          merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -199,36 +209,19 @@ jobs:
   release:
     name: Add ${{ matrix.artifact }} to release
     if: github.repository == 'Eeems/remarkable-update-image' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
-    needs: [build-sdist, build-wheel]
+    needs: *release-needs
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        artifact:
-          - "pip-sdist"
-          - "pip-wheel-ubuntu-latest-3.11"
-          - "pip-wheel-ubuntu-latest-3.12"
-          - "pip-wheel-ubuntu-latest-3.13"
-          - "pip-wheel-windows-latest-3.11"
-          - "pip-wheel-windows-latest-3.12"
-          - "pip-wheel-windows-latest-3.13"
-          - "pip-wheel-macos-latest-3.11"
-          - "pip-wheel-macos-latest-3.12"
-          - "pip-wheel-macos-latest-3.13"
-          - "pip-wheel-macos-15-intel-3.11"
-          - "pip-wheel-macos-15-intel-3.12"
-          - "pip-wheel-macos-15-intel-3.13"
     permissions:
       contents: write
     steps:
       - name: Checkout the Git repository
-        uses: actions/checkout@v4
-      - name: Download executable
+        uses: actions/checkout@v6
+      - name: Download pip packages
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.artifact }}
-          path: dist
+          pattern: pip-*
+          merge-multiple: true
       - name: Upload to release
         run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:

--- a/Makefile
+++ b/Makefile
@@ -51,16 +51,20 @@ WHEEL_NAME := $(shell python wheel_name.py)
 _PYTHON_HOST_PLATFORM := $(shell python wheel_name.py --platform)
 ARCHFLAGS := $(shell python wheel_name.py --archflags)
 
+.PHONY: clean
 clean:
 	if [ -d .venv/mnt ] && mountpoint -q .venv/mnt; then \
 	    umount -ql .venv/mnt; \
 	fi
 	git clean --force -dX
 
+.PHONY: build
 build: wheel
 
+.PHONY: release
 release: wheel sdist
 
+.PHONY: install
 install: wheel
 	if type pipx > /dev/null; then \
 	    pipx install \
@@ -75,9 +79,14 @@ install: wheel
 	        ${PACKAGE}; \
 	fi
 
+.PHONY: sdist
 sdist: dist/${PACKAGE}-${VERSION}.tar.gz
 
-wheel: dist/${WHEEL_NAME}
+.PHONY: wheel
+native-wheel: dist/${WHEEL_NAME}
+
+.PHONY: wheel
+wheel: dist/${PACKAGE}-${VERSION}-py3-none-any.whl
 
 dist:
 	mkdir -p dist
@@ -85,6 +94,10 @@ dist:
 dist/${PACKAGE}-${VERSION}.tar.gz: ${VENV_BIN_ACTIVATE} dist $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -m build --sdist
+
+dist/${PACKAGE}-${VERSION}-py3-none-any.whl: ${VENV_BIN_ACTIVATE} dist $(OBJ)
+	. ${VENV_BIN_ACTIVATE}; \
+	python -m build --wheel --config-setting=build_with_nuitka=false
 
 dist/${WHEEL_NAME}: ${VENV_BIN_ACTIVATE} dist $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
@@ -104,7 +117,6 @@ ${VENV_BIN_ACTIVATE}: requirements.txt
 	python -m pip install \
 	    --extra-index-url=https://wheels.eeems.codes/ \
 	    -r requirements.txt
-
 
 .data/codexctl.zip:
 	mkdir -p .data
@@ -140,40 +152,30 @@ $(PROTO_OBJ): $(PROTO_SOURCE) ${VENV_BIN_ACTIVATE}
 	    --proto_path=protobuf \
 	    $(PROTO_SOURCE)
 
+.PHONY: test
 test: ${VENV_BIN_ACTIVATE} $(IMAGES) $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u test.py
 
+.PHONY: all
 all: release
 
+.PHONY: lint
 lint: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff check
 
+.PHONY: lint-fix
 lint-fix: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff check
 
+.PHONY: format
 format: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff format --diff
 
+.PHONY: format-fix
 format-fix: $(VENV_BIN_ACTIVATE)
 	. $(VENV_BIN_ACTIVATE); \
 	python -m ruff format
-
-.PHONY: \
-	all \
-	build \
-	clean \
-	dev \
-	executable \
-	install \
-	release \
-	sdist \
-	wheel \
-	test \
-	lint \
-	lint-fix \
-	format \
-	format-fix

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ install: wheel
 .PHONY: sdist
 sdist: dist/${PACKAGE}-${VERSION}.tar.gz
 
-.PHONY: wheel
+.PHONY: native-wheel
 native-wheel: dist/${WHEEL_NAME}
 
 .PHONY: wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remarkable_update_image"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
   { name="Eeems", email="eeems@eeems.email" },
 ]

--- a/remarkable_update_image/image.py
+++ b/remarkable_update_image/image.py
@@ -4,21 +4,21 @@ import os
 import struct
 import sys
 import time
-import libconf
-
-from indexed_gzip import IndexedGzipFile as GzipFile
-
-from cachetools import TTLCache
 from hashlib import sha256
-from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+import libconf
+from cachetools import TTLCache
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.hashes import SHA256
-
-from .update_metadata_pb2 import DeltaArchiveManifest
-from .update_metadata_pb2 import InstallOperation
-from .update_metadata_pb2 import Signatures
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from indexed_gzip import IndexedGzipFile as GzipFile
 
 from .cpio import Archive
+from .update_metadata_pb2 import (
+    DeltaArchiveManifest,
+    InstallOperation,
+    Signatures,
+)
 
 
 def sizeof_fmt(num, suffix="B"):
@@ -335,7 +335,12 @@ class CPIOUpdateImage(io.RawIOBase):
         # TODO - handle possibilities of multiple images
         info = self._info["stable"]["copy1"]["images"][0]
         entry = self._archive[info["filename"]]
-        self._image = GzipFile(fileobj=entry, mode="rb")
+        self._image: GzipFile = GzipFile(fileobj=entry, mode="rb")
+        # Read entire image to allow seeking based on io.SEEK_END
+        while self._image.read(131_672):
+            pass
+
+        _ = self._image.seek(0, io.SEEK_SET)
 
     def verify(self, publickey):
         # TODO - verify signature

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cryptography==46.0.6
 protobuf==5.29.6
 ext4==1.3
 libconf==2.0.1
-indexed-gzip==1.10.1
+indexed-gzip==1.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==46.0.6
 protobuf==5.29.6
-ext4==1.2.4
+ext4==1.3
 libconf==2.0.1
 indexed-gzip==1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==46.0.6
 protobuf==5.29.6
-ext4==1.3
+ext4==1.3.1
 libconf==2.0.1
 indexed-gzip==1.10.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 1.3.3
  * Updated dependencies (ext4 and indexed-gzip) to newer pinned versions
  * Improved CI/CD workflows and wheel build process for more consistent distribution artifacts

* **Bug Fixes**
  * Improved handling of compressed update images for more reliable reading and processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->